### PR TITLE
Use TwigExtension instead of ConfigPass to prune menu items

### DIFF
--- a/src/Helper/MenuHelper.php
+++ b/src/Helper/MenuHelper.php
@@ -1,15 +1,14 @@
 <?php
 
-namespace AlterPHP\EasyAdminExtensionBundle\Configuration;
+namespace AlterPHP\EasyAdminExtensionBundle\Helper;
 
-use EasyCorp\Bundle\EasyAdminBundle\Configuration\ConfigPassInterface;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 
 /**
  * @author Pierre-Charles Bertineau <pc.bertineau@alterphp.com>
  */
-class MenuConfigPass implements ConfigPassInterface
+class MenuHelper
 {
     protected $tokenStorage;
     protected $authorizationChecker;
@@ -20,16 +19,12 @@ class MenuConfigPass implements ConfigPassInterface
         $this->authorizationChecker = $authorizationChecker;
     }
 
-    public function process(array $backendConfig)
+    public function pruneMenuItems(array $menuConfig)
     {
-        $menuConfig = $backendConfig['design']['menu'];
-
         $menuConfig = $this->pruneAccessDeniedEntries($menuConfig);
         $menuConfig = $this->pruneEmptyFolderEntries($menuConfig);
 
-        $backendConfig['design']['menu'] = $menuConfig;
-
-        return $backendConfig;
+        return $menuConfig;
     }
 
     protected function pruneAccessDeniedEntries(array $menuConfig)

--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -30,11 +30,13 @@
             <argument type="service" id="security.authorization_checker"/>
             <argument>%easy_admin_extension.minimum_role%</argument>
         </service>
-        <service id="alterphp.easyadmin_extension.config_pass.menu" class="AlterPHP\EasyAdminExtensionBundle\Configuration\MenuConfigPass">
+        <service id="alterphp.easyadmin_extension.helper.menu" class="AlterPHP\EasyAdminExtensionBundle\Helper\MenuHelper">
             <argument type="service" id="security.token_storage"/>
             <argument type="service" id="security.authorization_checker"/>
-            <!-- Makes it process just before PropertyConfigPass -->
-            <tag name="easyadmin.config_pass" priority="69"/>
+        </service>
+        <service id="alterphp.easyadmin_extension.twig.extension.menu" class="AlterPHP\EasyAdminExtensionBundle\Twig\MenuExtension">
+            <argument type="service" id="alterphp.easyadmin_extension.helper.menu"/>
+            <tag name="twig.extension"/>
         </service>
     </services>
 </container>

--- a/src/Resources/views/default/menu.html.twig
+++ b/src/Resources/views/default/menu.html.twig
@@ -1,0 +1,6 @@
+{% extends '@BaseEasyAdmin/default/menu.html.twig' %}
+
+{% block main_menu %}
+  {% set _menu_items = _menu_items|prune_menu_items %}
+  {{ parent() }}
+{% endblock %}

--- a/src/Twig/MenuExtension.php
+++ b/src/Twig/MenuExtension.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AlterPHP\EasyAdminExtensionBundle\Twig;
+
+use Symfony\Component\Form\FormView;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+
+class MenuExtension extends AbstractExtension
+{
+    protected $menuHelper;
+
+    public function __construct($menuHelper)
+    {
+        $this->menuHelper = $menuHelper;
+    }
+
+    public function getFilters()
+    {
+        return array(
+            new TwigFilter('prune_menu_items', array($this, 'pruneMenuItems')),
+        );
+    }
+
+    public function pruneMenuItems(array $menuConfig)
+    {
+        return $this->menuHelper->pruneMenuItems($menuConfig);
+    }
+}


### PR DESCRIPTION
Fix #7 