### PR TITLE
Set default translation domain from EasyAdmin configuration.

### DIFF
--- a/src/Configuration/ListFormFiltersConfigPass.php
+++ b/src/Configuration/ListFormFiltersConfigPass.php
@@ -107,7 +107,7 @@ class ListFormFiltersConfigPass implements ConfigPassInterface
 
         if ($entityMetadata->hasField($filterConfig['property'])) {
             $this->configureFieldFilter(
-                $entityClass, $entityMetadata->getFieldMapping($filterConfig['property']), $filterConfig, string $translationDomain
+                $entityClass, $entityMetadata->getFieldMapping($filterConfig['property']), $filterConfig, $translationDomain
             );
         } elseif ($entityMetadata->hasAssociation($filterConfig['property'])) {
             $this->configureAssociationFilter(


### PR DESCRIPTION
Sets translation domain for the filter forms from the EasyAdmin configuration instead of using EasyAdminBundle all the time.