### PR TITLE
Add TextField type to filters

### DIFF
--- a/src/Configuration/ListFormFiltersConfigPass.php
+++ b/src/Configuration/ListFormFiltersConfigPass.php
@@ -138,6 +138,9 @@ class ListFormFiltersConfigPass implements ConfigPassInterface
                     'choice_translation_domain' => $translationDomain,
                 );
                 break;
+            case 'text':
+                $filterConfig['type'] = TextFeld::class;
+                break;                
             default:
                 return;
         }


### PR DESCRIPTION
By adding a Text / TextField type to filters allows you to add specific field search.

eg - find by ID
```
form_filters:
                      - { property: id, type: text}
```