### PR TITLE
Remove referer from masterRequest URI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "doctrine/orm": "^2.6",
         "easycorp/easyadmin-bundle": "^2.0",
         "league/uri-manipulations": "^1.3",
+        "league/uri-schemes": "^1.2",
         "symfony/config": "^4.1",
         "symfony/dependency-injection": "^4.1",
         "symfony/event-dispatcher": "^4.1",

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "doctrine/doctrine-bundle": "^1.8",
         "doctrine/orm": "^2.6",
         "easycorp/easyadmin-bundle": "^2.0",
+        "league/uri-manipulations": "^1.3",
         "symfony/config": "^4.1",
         "symfony/dependency-injection": "^4.1",
         "symfony/event-dispatcher": "^4.1",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,10 @@
         "symfony/var-dumper": "^4.1"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "platform": {
+            "ext-intl": "1.0"
+        }
     },
     "autoload": {
         "psr-4": { "AlterPHP\\EasyAdminExtensionBundle\\": "src/" },

--- a/docker-compose.yml.dist
+++ b/docker-compose.yml.dist
@@ -2,20 +2,13 @@ version: '3.2'
 
 services:
 
-    php:
-        image: php
-        volumes:
-            - ./:/app
-        entrypoint:
-          - php
-
     phpunit:
         build: docker/phpunit
         volumes:
             - ./:/app
         entrypoint:
           - php
-          - /app/vendor/phpunit/phpunit/phpunit
+          - /app/vendor/bin/simple-phpunit
 
     php-cs-fixer:
         image: ekreative/php-cs-fixer

--- a/src/Controller/EasyAdminController.php
+++ b/src/Controller/EasyAdminController.php
@@ -5,7 +5,8 @@ namespace AlterPHP\EasyAdminExtensionBundle\Controller;
 use AlterPHP\EasyAdminExtensionBundle\Security\AdminAuthorizationChecker;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\EasyAdminController as BaseEasyAdminControler;
 use EasyCorp\Bundle\EasyAdminBundle\Event\EasyAdminEvents;
-use League\Uri;
+use League\Uri\Modifiers\RemoveQueryParams;
+use League\Uri\Schemes\Http;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 class EasyAdminController extends BaseEasyAdminControler
@@ -28,8 +29,9 @@ class EasyAdminController extends BaseEasyAdminControler
         $baseMasterRequestUri = !$this->request->isXmlHttpRequest()
                             ? $this->get('request_stack')->getMasterRequest()->getUri()
                             : $this->request->headers->get('referer');
-        $baseMasterRequestUri = Uri\create($baseMasterRequestUri);
-        $masterRequestUri = Uri\remove_pairs($baseMasterRequestUri, ['referer']);
+        $baseMasterRequestUri = Http::createFromString($baseMasterRequestUri);
+        $removeRefererModifier = new RemoveQueryParams(['referer']);
+        $masterRequestUri = $removeRefererModifier->process($baseMasterRequestUri);
 
         return $this->render('@EasyAdminExtension/default/embedded_list.html.twig', [
             'paginator' => $paginator,

--- a/src/Controller/EasyAdminController.php
+++ b/src/Controller/EasyAdminController.php
@@ -5,6 +5,7 @@ namespace AlterPHP\EasyAdminExtensionBundle\Controller;
 use AlterPHP\EasyAdminExtensionBundle\Security\AdminAuthorizationChecker;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\EasyAdminController as BaseEasyAdminControler;
 use EasyCorp\Bundle\EasyAdminBundle\Event\EasyAdminEvents;
+use League\Uri;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 class EasyAdminController extends BaseEasyAdminControler
@@ -23,10 +24,17 @@ class EasyAdminController extends BaseEasyAdminControler
 
         $this->dispatch(EasyAdminEvents::POST_LIST, ['paginator' => $paginator]);
 
+        // Removes existing referer
+        $baseMasterRequestUri = !$this->request->isXmlHttpRequest()
+                            ? $this->get('request_stack')->getMasterRequest()->getUri()
+                            : $this->request->headers->get('referer');
+        $baseMasterRequestUri = Uri\create($baseMasterRequestUri);
+        $masterRequestUri = Uri\remove_pairs($baseMasterRequestUri, ['referer']);
+
         return $this->render('@EasyAdminExtension/default/embedded_list.html.twig', [
             'paginator' => $paginator,
             'fields' => $fields,
-            'masterRequest' => $this->get('request_stack')->getMasterRequest(),
+            'masterRequestUri' => (string) $masterRequestUri,
         ]);
     }
 

--- a/src/Resources/views/default/embedded_list.html.twig
+++ b/src/Resources/views/default/embedded_list.html.twig
@@ -4,7 +4,7 @@
 
 {# OVERRIDE referer #}
 {% set _request_parameters = app.request.query.all %}
-{% set _request_parameters = _request_parameters|merge({ referer: masterRequest.requestUri|url_encode }) %}
+{% set _request_parameters = _request_parameters|merge({ referer: masterRequestUri }) %}
 
 {% set widget_identifier = app.request.requestUri|embedded_list_identifier %}
 


### PR DESCRIPTION
Referer generated in embedded list links was longer and longer as much user clicked on sorting headers. It's fixed now.

When editing an entity from an embedded list and submitting, user is now redirected to the previous page. It was not always achieved before.