### PR TITLE
refs #117 : fix retrieving href in ajax pagination link

### DIFF
--- a/src/Resources/public/js/easyadmin-extension.js
+++ b/src/Resources/public/js/easyadmin-extension.js
@@ -6,7 +6,7 @@ function reloadEmbeddedList(identifier, toggleBaseUrl) {
     .on('click', 'th a', function (e) {
       e.preventDefault();
       $.ajax({
-        url: e.target.href,
+        url: e.currentTarget.href,
         dataType: 'html',
         success: function (data, textStatus, jqXHR) {
           $(containerPrefix).replaceWith(data);
@@ -16,7 +16,7 @@ function reloadEmbeddedList(identifier, toggleBaseUrl) {
     .on('click', '.list-pagination a', function (e) {
       e.preventDefault();
       $.ajax({
-        url: e.target.href,
+        url: e.currentTarget.href,
         dataType: 'html',
         success: function (data, textStatus, jqXHR) {
           $(containerPrefix).replaceWith(data);


### PR DESCRIPTION
`e.target` contains the element that trigger the "click"
Since `A` tag can contains `SPAN` to displays icons, e.target is the `SPAN`, so we can't get the `href` from it.
`e.currentTarget` return the element on which we have attach the click -> `A`