### PR TITLE
Fixed if use equal entity on two custom config

### DIFF
--- a/src/Helper/EmbeddedListHelper.php
+++ b/src/Helper/EmbeddedListHelper.php
@@ -85,18 +85,6 @@ class EmbeddedListHelper
             );
         }
 
-        if (1 < \count($matchingEntityConfigs)) {
-            throw new \RuntimeException(
-                \sprintf(
-                    'More than 1 entity defined in EasyAdmin configuration matches %s FQCN.'.
-                    ' Try setting option "entity" (in type_options for NEW/EDIT/FORM view, or template_options for SHOW view)'.
-                    ' with one of [%s].',
-                    $entityFqcn,
-                    \implode(', ', $matchingEntityConfigs)
-                )
-            );
-        }
-
         return (string) \key($matchingEntityConfigs);
     }
 


### PR DESCRIPTION
Example use EventEmbed:
```yaml
easy_admin:
    entities:
        Event:
            class: App\Entity\Event
            list:
                fields:
                    - { property: id , label: 'Id One' }
        EventEmbed:
            class: App\Entity\Event
            list:
                fields:
                    - { property: id , label: 'Id Two Embed' }
        Promoter:
            class: App\Entity\Promoter
            form:
                fields:
                    - { property: events, type: embedded_list, type_options: { entity: EventEmbed } }
```