### PR TITLE
Make EasyAdmin's dynamic filters compatible with current implementation

### DIFF
--- a/src/EventListener/PostQueryBuilderSubscriber.php
+++ b/src/EventListener/PostQueryBuilderSubscriber.php
@@ -133,6 +133,11 @@ class PostQueryBuilderSubscriber implements EventSubscriberInterface
             return;
         }
 
+        // Ignore EasyAdmin's dynamic filters
+        if (\is_array($value) && array_key_exists('comparison', $value)) {
+            return;
+        }
+
         // Add root entity alias if none provided
         $queryField = $listFilter->getProperty();
         if (false === \strpos($queryField, '.')) {


### PR DESCRIPTION
Hi,

I love this bundle, I'm probably using all of it's features and I am glad EasyAdmin is implementing some the features it pioneered.

One of them is the dynamic filters feature.

I stumbled upon this issue #153 because I had to perform some custom-filtering and the easy way to go was with the new filters feature.

I've read you said you wanted to perform a major refactor removing this bundle's filters in favor of EasyAdmin's altogether sometime in the future when you have time.

In the meantime I needed the logic to be compatible and it was very easy because of how EasyAdmin's implemented it's filters, I could perform a "form check" to ignore them.

The issue was the `PostQueryBuilderSubscriber` was repeating the filters thinking the array provided by easyadmin was an `IN` sql clause.

Locally works great! Hope it makes to the next release. I'm using a fork of it.

PD: EasyAdmin is now at 2.3.0 and would be a pity the community loose this bundle behind