### PR TITLE
Fix deprecation for using spaceless tag

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "symfony/http-kernel": "~3.0|^4.0",
         "symfony/property-access": "~3.0|^4.0",
         "symfony/validator": "~3.0|^4.0",
-        "twig/twig": "~1.26|~2.0"
+        "twig/twig": "~1.38|~2.0"
     },
     "require-dev": {
         "doctrine/doctrine-fixtures-bundle": "~2.2",

--- a/src/Resources/views/default/embedded_list.html.twig
+++ b/src/Resources/views/default/embedded_list.html.twig
@@ -9,14 +9,14 @@
 {% set widget_identifier = app.request.requestUri|embedded_list_identifier %}
 
 {% set _content_title %}
-{% spaceless %}
+{% apply spaceless %}
     {% if 'search' == app.request.get('action') %}
         {{ 'search.page_title'|transchoice(paginator.nbResults, {}, 'EasyAdminBundle')|raw }}
     {% else %}
         {% set _default_title = 'list.page_title'|trans(_trans_parameters, 'EasyAdminBundle') %}
         {{ _entity_config.list.title is defined ? _entity_config.list.title|trans(_trans_parameters) : _default_title }}
     {% endif %}
-{% endspaceless %}
+{% endapply %}
 {% endset %}
 
 {% block main %}


### PR DESCRIPTION
`User Deprecated: The spaceless tag in "@EasyAdminExtension/default/embedded_list.html.twig" at line 12 is deprecated since Twig 2.7, use the spaceless filter instead.`

I am using symfony 3.4