### PR TITLE
composer: allow easy admin bundle that allows Symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "doctrine/common": "^2.8",
         "doctrine/doctrine-bundle": "^1.8|^2.0",
         "doctrine/orm": "^2.6",
-        "easycorp/easyadmin-bundle": "^2.0,<2.2.0",
+        "easycorp/easyadmin-bundle": "^2.0",
         "league/uri-manipulations": "^1.3",
         "league/uri-schemes": "^1.2",
         "symfony/config": "^4.1",


### PR DESCRIPTION
Follow up to https://github.com/alterphp/EasyAdminExtensionBundle/pull/163

Not sure why this is locked to stricly, but it blocks EasyAdminBundle actually allows Symfony 5 - **2.3.2**

![image](https://user-images.githubusercontent.com/924196/69495327-1c570580-0ec6-11ea-9645-015d7ce79287.png)


Fixes:

![image](https://user-images.githubusercontent.com/924196/69495321-077a7200-0ec6-11ea-8882-a5974d39401c.png)


