### PR TITLE
feat: Controller now use trait for better use in EasyAdmin

### DIFF
--- a/src/Controller/AdminExtensionControllerTrait.php
+++ b/src/Controller/AdminExtensionControllerTrait.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace AlterPHP\EasyAdminExtensionBundle\Controller;
+
+use AlterPHP\EasyAdminExtensionBundle\Security\AdminAuthorizationChecker;
+use EasyCorp\Bundle\EasyAdminBundle\Event\EasyAdminEvents;
+use League\Uri\Modifiers\RemoveQueryParams;
+use League\Uri\Schemes\Http;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+trait AdminExtensionControllerTrait
+{
+    public static function getSubscribedServices(): array
+    {
+        return \array_merge(parent::getSubscribedServices(), [AdminAuthorizationChecker::class]);
+    }
+
+    protected function embeddedListAction()
+    {
+        $this->dispatch(EasyAdminEvents::PRE_LIST);
+
+        $maxResults = (int) $this->request->query->get('max-results', $this->config['list']['max_results']);
+
+        $paginator = $this->findAll($this->entity['class'], $this->request->query->get('page', 1), $maxResults, $this->request->query->get('sortField'), $this->request->query->get('sortDirection'), $this->entity['list']['dql_filter']);
+
+        $this->dispatch(EasyAdminEvents::POST_LIST, ['paginator' => $paginator]);
+
+        // Filter displaid columns
+        $hiddenFields = $this->request->query->get('hidden-fields', []);
+        $fields = \array_filter(
+            $this->entity['list']['fields'],
+            function ($name) use ($hiddenFields) {
+                return !\in_array($name, $hiddenFields);
+            },
+            ARRAY_FILTER_USE_KEY
+        );
+
+        // Removes existing referer
+        $baseMasterRequestUri = !$this->request->isXmlHttpRequest()
+            ? $this->get('request_stack')->getMasterRequest()->getUri()
+            : $this->request->headers->get('referer');
+        $baseMasterRequestUri = Http::createFromString($baseMasterRequestUri);
+        $removeRefererModifier = new RemoveQueryParams(['referer']);
+        $masterRequestUri = $removeRefererModifier->process($baseMasterRequestUri);
+
+        $requestParameters = $this->request->query->all();
+        $requestParameters['referer'] = (string) $masterRequestUri;
+
+        $viewVars = [
+            'paginator' => $paginator,
+            'fields' => $fields,
+            '_request_parameters' => $requestParameters,
+        ];
+
+        return $this->executeDynamicMethod(
+            'render<EntityName>Template',
+            ['embeddedList', $this->entity['embeddedList']['template'], $viewVars]
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @throws \Symfony\Component\Security\Core\Exception\AccessDeniedException
+     */
+    protected function isActionAllowed($actionName)
+    {
+        switch ($actionName) {
+            // autocomplete action is mapped to list action for access permissions
+            case 'autocomplete':
+                // filters (EasyAdmin new list filters) action is mapped to list action for access permissions
+            case 'filters':
+                // embeddedList action is mapped to list action for access permissions
+            case 'embeddedList':
+                $actionName = 'list';
+                break;
+            // newAjax action is mapped to new action for access permissions
+            case 'newAjax':
+                $actionName = 'new';
+                break;
+            default:
+                break;
+        }
+
+        // Get item for edit/show or custom actions => security voters may apply
+        $easyadmin = $this->request->attributes->get('easyadmin');
+        $subject = $easyadmin['item'] ?? null;
+        $this->get(AdminAuthorizationChecker::class)->checksUserAccess($this->entity, $actionName, $subject);
+
+        return parent::isActionAllowed($actionName);
+    }
+
+    /**
+     * The method that is executed when the user performs a 'new ajax' action on an entity.
+     *
+     * @return JsonResponse
+     */
+    protected function newAjaxAction()
+    {
+        $this->dispatch(EasyAdminEvents::PRE_NEW);
+
+        $entity = $this->executeDynamicMethod('createNew<EntityName>Entity');
+        $easyadmin = \array_merge($this->request->attributes->get('easyadmin'), ['item' => $entity]);
+        $this->request->attributes->set('easyadmin', $easyadmin);
+
+        $fields = $this->entity['new']['fields'];
+        $newForm = $this->executeDynamicMethod('create<EntityName>NewForm', [$entity, $fields]);
+        $newForm->handleRequest($this->request);
+        if ($newForm->isSubmitted() && $newForm->isValid()) {
+            $this->dispatch(EasyAdminEvents::PRE_PERSIST, ['entity' => $entity]);
+            $this->executeDynamicMethod('persist<EntityName>Entity', [$entity]);
+            $this->dispatch(EasyAdminEvents::POST_PERSIST, ['entity' => $entity]);
+
+            return new JsonResponse(['option' => ['id' => $entity->getId(), 'text' => (string) $entity]]);
+        }
+
+        $this->dispatch(EasyAdminEvents::POST_NEW, ['entity_fields' => $fields, 'form' => $newForm, 'entity' => $entity]);
+
+        $parameters = ['form' => $newForm->createView(), 'entity_fields' => $fields, 'entity' => $entity];
+        $templatePath = '@EasyAdminExtension/default/new_ajax.html.twig';
+        if (isset($this->entity['templates']['new_ajax'])) {
+            $templatePath = $this->entity['templates']['new_ajax'];
+        }
+
+        return new JsonResponse(['html' => $this->renderView($templatePath, $parameters)]);
+    }
+}

--- a/src/Controller/AdminExtensionControllerTrait.php
+++ b/src/Controller/AdminExtensionControllerTrait.php
@@ -10,11 +10,6 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 
 trait AdminExtensionControllerTrait
 {
-    public static function getSubscribedServices(): array
-    {
-        return \array_merge(parent::getSubscribedServices(), [AdminAuthorizationChecker::class]);
-    }
-
     protected function embeddedListAction()
     {
         $this->dispatch(EasyAdminEvents::PRE_LIST);

--- a/src/Controller/EasyAdminController.php
+++ b/src/Controller/EasyAdminController.php
@@ -13,4 +13,9 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 class EasyAdminController extends BaseEasyAdminControler
 {
     use AdminExtensionControllerTrait;
+	
+	public static function getSubscribedServices(): array
+    {
+        return \array_merge(parent::getSubscribedServices(), [AdminAuthorizationChecker::class]);
+    }
 }

--- a/src/Controller/EasyAdminController.php
+++ b/src/Controller/EasyAdminController.php
@@ -6,7 +6,6 @@ use AlterPHP\EasyAdminExtensionBundle\Security\AdminAuthorizationChecker;
 use AlterPHP\EasyAdminExtensionBundle\Controller\AdminExtensionControllerTrait;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\EasyAdminController as BaseEasyAdminControler;
 
-
 class EasyAdminController extends BaseEasyAdminControler
 {
     use AdminExtensionControllerTrait;

--- a/src/Controller/EasyAdminController.php
+++ b/src/Controller/EasyAdminController.php
@@ -3,6 +3,7 @@
 namespace AlterPHP\EasyAdminExtensionBundle\Controller;
 
 use AlterPHP\EasyAdminExtensionBundle\Security\AdminAuthorizationChecker;
+use AlterPHP\EasyAdminExtensionBundle\Controller\AdminExtensionControllerTrait;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\EasyAdminController as BaseEasyAdminControler;
 use EasyCorp\Bundle\EasyAdminBundle\Event\EasyAdminEvents;
 use League\Uri\Modifiers\RemoveQueryParams;
@@ -11,118 +12,5 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 
 class EasyAdminController extends BaseEasyAdminControler
 {
-    public static function getSubscribedServices(): array
-    {
-        return \array_merge(parent::getSubscribedServices(), [AdminAuthorizationChecker::class]);
-    }
-
-    protected function embeddedListAction()
-    {
-        $this->dispatch(EasyAdminEvents::PRE_LIST);
-
-        $maxResults = (int) $this->request->query->get('max-results', $this->config['list']['max_results']);
-
-        $paginator = $this->findAll($this->entity['class'], $this->request->query->get('page', 1), $maxResults, $this->request->query->get('sortField'), $this->request->query->get('sortDirection'), $this->entity['list']['dql_filter']);
-
-        $this->dispatch(EasyAdminEvents::POST_LIST, ['paginator' => $paginator]);
-
-        // Filter displaid columns
-        $hiddenFields = $this->request->query->get('hidden-fields', []);
-        $fields = \array_filter(
-            $this->entity['list']['fields'],
-            function ($name) use ($hiddenFields) {
-                return !\in_array($name, $hiddenFields);
-            },
-            ARRAY_FILTER_USE_KEY
-        );
-
-        // Removes existing referer
-        $baseMasterRequestUri = !$this->request->isXmlHttpRequest()
-                            ? $this->get('request_stack')->getMasterRequest()->getUri()
-                            : $this->request->headers->get('referer');
-        $baseMasterRequestUri = Http::createFromString($baseMasterRequestUri);
-        $removeRefererModifier = new RemoveQueryParams(['referer']);
-        $masterRequestUri = $removeRefererModifier->process($baseMasterRequestUri);
-
-        $requestParameters = $this->request->query->all();
-        $requestParameters['referer'] = (string) $masterRequestUri;
-
-        $viewVars = [
-            'paginator' => $paginator,
-            'fields' => $fields,
-            '_request_parameters' => $requestParameters,
-        ];
-
-        return $this->executeDynamicMethod(
-            'render<EntityName>Template',
-            ['embeddedList', $this->entity['embeddedList']['template'], $viewVars]
-        );
-    }
-
-    /**
-     * {@inheritdoc}
-     *
-     * @throws \Symfony\Component\Security\Core\Exception\AccessDeniedException
-     */
-    protected function isActionAllowed($actionName)
-    {
-        switch ($actionName) {
-            // autocomplete action is mapped to list action for access permissions
-            case 'autocomplete':
-            // filters (EasyAdmin new list filters) action is mapped to list action for access permissions
-            case 'filters':
-            // embeddedList action is mapped to list action for access permissions
-            case 'embeddedList':
-                $actionName = 'list';
-                break;
-            // newAjax action is mapped to new action for access permissions
-            case 'newAjax':
-                $actionName = 'new';
-                break;
-            default:
-                break;
-        }
-
-        // Get item for edit/show or custom actions => security voters may apply
-        $easyadmin = $this->request->attributes->get('easyadmin');
-        $subject = $easyadmin['item'] ?? null;
-        $this->get(AdminAuthorizationChecker::class)->checksUserAccess($this->entity, $actionName, $subject);
-
-        return parent::isActionAllowed($actionName);
-    }
-
-    /**
-     * The method that is executed when the user performs a 'new ajax' action on an entity.
-     *
-     * @return JsonResponse
-     */
-    protected function newAjaxAction()
-    {
-        $this->dispatch(EasyAdminEvents::PRE_NEW);
-
-        $entity = $this->executeDynamicMethod('createNew<EntityName>Entity');
-        $easyadmin = \array_merge($this->request->attributes->get('easyadmin'), ['item' => $entity]);
-        $this->request->attributes->set('easyadmin', $easyadmin);
-
-        $fields = $this->entity['new']['fields'];
-        $newForm = $this->executeDynamicMethod('create<EntityName>NewForm', [$entity, $fields]);
-        $newForm->handleRequest($this->request);
-        if ($newForm->isSubmitted() && $newForm->isValid()) {
-            $this->dispatch(EasyAdminEvents::PRE_PERSIST, ['entity' => $entity]);
-            $this->executeDynamicMethod('persist<EntityName>Entity', [$entity]);
-            $this->dispatch(EasyAdminEvents::POST_PERSIST, ['entity' => $entity]);
-
-            return new JsonResponse(['option' => ['id' => $entity->getId(), 'text' => (string) $entity]]);
-        }
-
-        $this->dispatch(EasyAdminEvents::POST_NEW, ['entity_fields' => $fields, 'form' => $newForm, 'entity' => $entity]);
-
-        $parameters = ['form' => $newForm->createView(), 'entity_fields' => $fields, 'entity' => $entity];
-        $templatePath = '@EasyAdminExtension/default/new_ajax.html.twig';
-        if (isset($this->entity['templates']['new_ajax'])) {
-            $templatePath = $this->entity['templates']['new_ajax'];
-        }
-
-        return new JsonResponse(['html' => $this->renderView($templatePath, $parameters)]);
-    }
+    use AdminExtensionControllerTrait;
 }

--- a/src/Controller/EasyAdminController.php
+++ b/src/Controller/EasyAdminController.php
@@ -9,8 +9,8 @@ use EasyCorp\Bundle\EasyAdminBundle\Controller\EasyAdminController as BaseEasyAd
 class EasyAdminController extends BaseEasyAdminControler
 {
     use AdminExtensionControllerTrait;
-	
-	public static function getSubscribedServices(): array
+
+    public static function getSubscribedServices(): array
     {
         return \array_merge(parent::getSubscribedServices(), [AdminAuthorizationChecker::class]);
     }

--- a/src/Controller/EasyAdminController.php
+++ b/src/Controller/EasyAdminController.php
@@ -5,10 +5,7 @@ namespace AlterPHP\EasyAdminExtensionBundle\Controller;
 use AlterPHP\EasyAdminExtensionBundle\Security\AdminAuthorizationChecker;
 use AlterPHP\EasyAdminExtensionBundle\Controller\AdminExtensionControllerTrait;
 use EasyCorp\Bundle\EasyAdminBundle\Controller\EasyAdminController as BaseEasyAdminControler;
-use EasyCorp\Bundle\EasyAdminBundle\Event\EasyAdminEvents;
-use League\Uri\Modifiers\RemoveQueryParams;
-use League\Uri\Schemes\Http;
-use Symfony\Component\HttpFoundation\JsonResponse;
+
 
 class EasyAdminController extends BaseEasyAdminControler
 {


### PR DESCRIPTION
This pull request modify the **EasyAdminController** to use a **trait** and make it easier to use other extension with **EasyAdmin**. (Example: [WandiParis/EasyAdminPlusBundle](https://github.com/WandiParis/EasyAdminPlusBundle))


It has been tested on a local projet that use both **Wandi** and **AlterPHP** extensions.

```
use Wandi\EasyAdminPlusBundle\Controller\AdminController as WandiController;
use AlterPHP\EasyAdminExtensionBundle\Controller\AdminExtensionControllerTrait as AlterPHPTrait;

class CustomAdminController extends WandiController
{
    use AlterPHPTrait;
    //....
}
```

I will try to contact other developer such as Wandi to try and do the same and it will make it better for EasyAdmin users to use multiple extensions.