### PR TITLE
Remove the need for League Uri

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,6 @@
         "doctrine/doctrine-bundle": "^1.8|^2.0",
         "doctrine/orm": "^2.6",
         "easycorp/easyadmin-bundle": "^2.2.2",
-        "league/uri-manipulations": "^1.3",
-        "league/uri-schemes": "^1.2",
         "symfony/config": "^4.2|^5.0",
         "symfony/dependency-injection": "^4.2|^5.0",
         "symfony/event-dispatcher": "^4.2|^5.0",

--- a/src/Controller/AdminExtensionControllerTrait.php
+++ b/src/Controller/AdminExtensionControllerTrait.php
@@ -4,8 +4,6 @@ namespace AlterPHP\EasyAdminExtensionBundle\Controller;
 
 use AlterPHP\EasyAdminExtensionBundle\Security\AdminAuthorizationChecker;
 use EasyCorp\Bundle\EasyAdminBundle\Event\EasyAdminEvents;
-use League\Uri\Modifiers\RemoveQueryParams;
-use League\Uri\Schemes\Http;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 trait AdminExtensionControllerTrait
@@ -34,12 +32,12 @@ trait AdminExtensionControllerTrait
         $baseMasterRequestUri = !$this->request->isXmlHttpRequest()
             ? $this->get('request_stack')->getMasterRequest()->getUri()
             : $this->request->headers->get('referer');
-        $baseMasterRequestUri = Http::createFromString($baseMasterRequestUri);
-        $removeRefererModifier = new RemoveQueryParams(['referer']);
-        $masterRequestUri = $removeRefererModifier->process($baseMasterRequestUri);
+        parse_str(parse_url($baseMasterRequestUri, PHP_URL_QUERY), $parameters);
+        unset($parameters['referer']);
+        $masterRequestUri = sprintf('%s?%s', strtok($baseMasterRequestUri, '?'), http_build_query($parameters));
 
         $requestParameters = $this->request->query->all();
-        $requestParameters['referer'] = (string) $masterRequestUri;
+        $requestParameters['referer'] = $masterRequestUri;
 
         $viewVars = [
             'paginator' => $paginator,

--- a/src/Controller/AdminExtensionControllerTrait.php
+++ b/src/Controller/AdminExtensionControllerTrait.php
@@ -32,9 +32,9 @@ trait AdminExtensionControllerTrait
         $baseMasterRequestUri = !$this->request->isXmlHttpRequest()
             ? $this->get('request_stack')->getMasterRequest()->getUri()
             : $this->request->headers->get('referer');
-        parse_str(parse_url($baseMasterRequestUri, PHP_URL_QUERY), $parameters);
-        unset($parameters['referer']);
-        $masterRequestUri = sprintf('%s?%s', strtok($baseMasterRequestUri, '?'), http_build_query($parameters));
+        \parse_str(\parse_url($baseMasterRequestUri, PHP_URL_QUERY), $queryParameters);
+        unset($queryParameters['referer']);
+        $masterRequestUri = \sprintf('%s?%s', \strtok($baseMasterRequestUri, '?'), \http_build_query($queryParameters));
 
         $requestParameters = $this->request->query->all();
         $requestParameters['referer'] = $masterRequestUri;


### PR DESCRIPTION
The usage of the package is very small. Just replaced it with some simple php functions.

Alternative to #183 without the need for the package and/or an upgrade.
Closes #182 when used instead of #183.