### PR TITLE
README: remove unnecessary assets files

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,14 +145,6 @@ Define your filters under `list`.`form_filters` entity configuration
 
 ```yaml
 easy_admin:
-    design:
-        assets:
-            css:
-                - 'bundles/easyadmin/bootstrap-all.css'
-            js:
-                # By default, EasyAdminBundle embeds a limited version of Bootstrap JS.
-                # For collapsible form filters to work, a full version should be added:
-                - 'bundles/easyadmin/bootstrap-all.js'
     entities:
         Animation:
             class: App\Entity\Animation


### PR DESCRIPTION
These files don't exist in my `public/` directory, **but** filters are collapsible. So it looks like we don't need this change anymore.

See #89