### PR TITLE
Fixes EmbedListHelper when the entity is a doctrine proxies

### DIFF
--- a/src/Helper/EmbeddedListHelper.php
+++ b/src/Helper/EmbeddedListHelper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AlterPHP\EasyAdminExtensionBundle\Helper;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
@@ -99,6 +100,7 @@ class EmbeddedListHelper
 
         $entityAssociations = $entityClassMetadata->getAssociationMappings();
         $parentEntityFqcn = \get_class($parentEntity);
+        $parentEntityFqcn = ClassUtils::getRealClass($parentEntityFqcn);
         foreach ($entityAssociations as $assoc) {
             // If association matches embeddedList relation
             if ($parentEntityFqcn === $assoc['targetEntity'] && $parentEntityProperty === $assoc['inversedBy']) {


### PR DESCRIPTION
Under some circumstance, the entity could be a proxy.

This is due to a combinaison of different factors:

* The current admin screen (organization) is on a sub property of the user
* The connected user / admin has relation or not to the organization
* Doctrine might lazy load admin's organization
* Doctrine has internal caches in UOW, and returns entity or proxy when loaded

So sometime, The following method [1] returns an instance of
`AppBundle\Entity\Organization`, and sometimes an instance of
`Proxies\__CG__\AppBundle\Entity\Organization`.

Thanks to this patch, we always retrieves the correct information metadata.

---

Oh, I forget to describe the original bug! When a proxy is returned, the
`EmbeddedListHelper` class could not find metadata. So it could not
filter the sub list. So the admin screen displays all projetcs (not for the current
organization but of the whole application :D )

[1] 
 https://github.com/EasyCorp/EasyAdminBundle/blob/bb128e7f19b4ec419cccdf773292a1ec3ee31978/src/EventListener/RequestPostInitializeListener.php#L68