### PR TITLE
Allow doctrine/common:3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^7.1.3",
         "doctrine/collections": "^1.5",
-        "doctrine/common": "^2.8",
+        "doctrine/common": "^2.8|^3.0",
         "doctrine/doctrine-bundle": "^1.8|^2.0",
         "doctrine/orm": "^2.6",
         "easycorp/easyadmin-bundle": "^2.2.2",

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^7.1.3",
         "doctrine/collections": "^1.5",
-        "doctrine/common": "^2.8|^3.0",
+        "doctrine/common": "^2.11|^3.0",
         "doctrine/doctrine-bundle": "^1.8|^2.0",
         "doctrine/orm": "^2.6",
         "easycorp/easyadmin-bundle": "^2.2.2",

--- a/src/Configuration/ListFormFiltersConfigPass.php
+++ b/src/Configuration/ListFormFiltersConfigPass.php
@@ -3,7 +3,7 @@
 namespace AlterPHP\EasyAdminExtensionBundle\Configuration;
 
 use AlterPHP\EasyAdminExtensionBundle\Model\ListFilter;
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\DBAL\Types\Type as DBALType;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use EasyCorp\Bundle\EasyAdminBundle\Configuration\ConfigPassInterface;

--- a/src/Helper/EmbeddedListHelper.php
+++ b/src/Helper/EmbeddedListHelper.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace AlterPHP\EasyAdminExtensionBundle\Helper;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\Common\Util\ClassUtils;
 use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**


### PR DESCRIPTION
This PR allows `doctrine/common:3.0` to allow compatibily with symfony 5.2

SF 5.2 requires `doctrine/persistance:2`
**BUT**
`doctrine/common:2` (the current version) requires `doctrine/persistance:1`

With this, we allow both version of `doctrine/common`, and so we allow both version
of `doctrine/persistance` and so SF 5.2 can select persistance 2 :tada: