### PR TITLE
Allow using custom action templates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,9 @@ easyadmin:
                     - { name: disable, icon: ban, title: Disable user, label: false, target: _blank, confirm: User will lose any access to the platform ! }
 ```
 
+To keep the confirmation modal behavior while creating [a custom action template](https://symfony.com/doc/2.x/bundles/EasyAdminBundle/tutorials/custom-actions.html#custom-templates-for-actions) you need to use the action template provided by this bundle, replacing ` {{ include('@EasyAdmin/default/action.html.twig') }}
+` by ` {{ include('@EasyAdminExtension/default/action.html.twig') }}`.
+
 ### Exclude fields in forms
 
 ```yaml

--- a/src/Resources/views/default/action.html.twig
+++ b/src/Resources/views/default/action.html.twig
@@ -1,0 +1,6 @@
+<a name="{{ action.name }}" class="{{ action.css_class|default('') }}" title="{{ action.title|default('') is empty ? '' : action.title|trans(trans_parameters, translation_domain) }}" {% if not confirm %}href="{{ action_href }}" target="{{ action.target }}"{% else %}href="#" data-href="{{ action_href }}" data-confirm="{{ confirm }}"{% endif %}>
+  {%- if action.icon %}<i class="fa fa-{{ action.icon }}"></i> {% endif -%}
+  {%- if action.label is defined and not action.label is empty -%}
+    {{ action.label|trans(trans_parameters|merge({ '%entity_id%': item_id }), translation_domain) }}
+  {%- endif -%}
+</a>

--- a/src/Resources/views/default/embedded_list.html.twig
+++ b/src/Resources/views/default/embedded_list.html.twig
@@ -69,13 +69,19 @@
                         {% set _column_label =  'list.row_actions'|trans(_trans_parameters, 'EasyAdminBundle') %}
                         <td class="actions">
                         {% block item_actions %}
-                            {{ include('@EasyAdmin/default/includes/_actions.html.twig', {
-                                actions: _list_item_actions|prune_item_actions(_entity_config, ['delete'], item),
-                                request_parameters: _request_parameters,
-                                translation_domain: _entity_config.translation_domain,
-                                trans_parameters: _trans_parameters,
-                                item_id: _item_id
-                            }, with_context = false) }}
+                          {% set _actions_template = _entity_config.list.collapse_actions
+                            ? '@EasyAdmin/default/includes/_actions_dropdown.html.twig'
+                            : '@EasyAdmin/default/includes/_actions.html.twig'
+                          %}
+                          {{ include(_actions_template, {
+                            actions: _list_item_actions|prune_item_actions(_entity_config, ['delete'], item),
+                            entity_config: _entity_config,
+                            request_parameters: _request_parameters,
+                            translation_domain: _entity_config.translation_domain,
+                            trans_parameters: _trans_parameters,
+                            item_id: _item_id,
+                            item: item
+                          }, with_context = false) }}
                         {% endblock item_actions %}
                         </td>
                     {% endif %}

--- a/src/Resources/views/default/includes/_actions.html.twig
+++ b/src/Resources/views/default/includes/_actions.html.twig
@@ -1,5 +1,3 @@
-{% import _self as action_macros %}
-
 {% for action in actions %}
   {% if 'list' == action.name %}
       {% set action_href = request_parameters.referer|default('') ? request_parameters.referer|easyadmin_urldecode : path('easyadmin', request_parameters|merge({ action: 'list' })) %}
@@ -14,14 +12,17 @@
     {% set confirm = (action.confirm|trans({}, translation_domain))|default('confirm_modal.content'|trans({}, 'EasyAdminBundle')) %}
   {% endif %}
 
-  {{ action_macros.action_tpl(action, item_id, action_href, confirm, trans_parameters, translation_domain) }}
-{% endfor %}
 
-{% macro action_tpl(action, item_id, action_href, confirm, trans_parameters, translation_domain) %}
-  <a name="{{ action.name }}" class="{{ action.css_class|default('') }}" title="{{ action.title|default('') is empty ? '' : action.title|trans(trans_parameters, translation_domain) }}" {% if not confirm %}href="{{ action_href }}" target="{{ action.target }}"{% else %}href="#" data-href="{{ action_href }}" data-confirm="{{ confirm }}"{% endif %}>
-    {%- if action.icon %}<i class="fa fa-{{ action.icon }}"></i> {% endif -%}
-    {%- if action.label is defined and not action.label is empty -%}
-      {{ action.label|trans(trans_parameters|merge({ '%entity_id%': item_id }), translation_domain) }}
-    {%- endif -%}
-  </a>
-{% endmacro %}
+  {{ include(action.template, {
+    action: action,
+    action_href: action_href,
+    is_dropdown: is_dropdown|default(false),
+    item: item,
+    item_id: item_id,
+    request_parameters: request_parameters,
+    translation_domain: translation_domain,
+    trans_parameters: trans_parameters,
+    confirm: confirm
+  }, with_context = false) }}
+
+{% endfor %}

--- a/src/Resources/views/form/bootstrap_4.html.twig
+++ b/src/Resources/views/form/bootstrap_4.html.twig
@@ -44,6 +44,7 @@
         request_parameters: _request_parameters,
         translation_domain: _translation_domain,
         trans_parameters: _trans_parameters,
-        item_id: _entity_id
+        item_id: _entity_id,
+        item: easyadmin.entity
     }, with_context = false) }}
 {% endblock item_actions %}


### PR DESCRIPTION
Before this change, using [custom template for actions](https://symfony.com/doc/2.x/bundles/EasyAdminBundle/tutorials/custom-actions.html#custom-templates-for-actions) wasn't possible, as well as [collapsing actions](https://symfony.com/doc/2.x/bundles/EasyAdminBundle/book/configuration-reference.html#collapse-actions).

I needed this feature, and I found a workaround for my use case, but as I've dug enough to be close to a solution and notice I wasn't the only one with this need ( #178 ), I decided to take a little more time to do it.

This PR makes it possible while keeping the [confirmation modal](https://symfony.com/doc/2.x/bundles/EasyAdminBundle/book/configuration-reference.html#collapse-actions).

It introduces a new `action.html.twig` template, which keeps the confirmation behavior. This is the new template to use when creating a custom template.

This PR also changes the `_actions_template` template selection, giving us the ability to use the collapsed version of actions.

Example:
`custom-template.html.twig`
```
#
{{ include('@EasyAdminExtension/default/action.html.twig') }}
#
```

```yaml
  list:
    actions:
      - {  name: actionName, icon: arrow-right, template: custom-template.twig }
```
<img width="140" alt="Capture d’écran 2021-06-17 à 10 24 50" src="https://user-images.githubusercontent.com/1864786/122360983-21235480-cf57-11eb-9a50-abd50cf10e0f.png">

```yaml
  list:
    collapse_actions: true
    actions:
      - { name: actionName, icon: arrow-right, template: custom-template.twig }
```

<img width="277" alt="Capture d’écran 2021-06-17 à 10 25 16" src="https://user-images.githubusercontent.com/1864786/122361056-326c6100-cf57-11eb-948a-6bade1223e0f.png">


Side note: the new action template differs slightly from the original one in the way it deals with translation and doesn't use the same CSS classes for the action icon. This was left unchanged.


