### PR TITLE
Fix http-foundation deprecation

### DIFF
--- a/src/Controller/AdminExtensionControllerTrait.php
+++ b/src/Controller/AdminExtensionControllerTrait.php
@@ -14,12 +14,12 @@ trait AdminExtensionControllerTrait
 
         $maxResults = (int) $this->request->query->get('max-results', $this->config['list']['max_results']);
 
-        $paginator = $this->findAll($this->entity['class'], $this->request->query->get('page', 1), $maxResults, $this->request->query->get('sortField'), $this->request->query->get('sortDirection'), $this->entity['list']['dql_filter']);
+        $paginator = $this->findAll($this->entity['class'], (int) $this->request->query->get('page', '1'), $maxResults, $this->request->query->get('sortField'), $this->request->query->get('sortDirection'), $this->entity['list']['dql_filter']);
 
         $this->dispatch(EasyAdminEvents::POST_LIST, ['paginator' => $paginator]);
 
         // Filter displaid columns
-        $hiddenFields = $this->request->query->get('hidden-fields', []);
+        $hiddenFields = (array) ($this->request->query->get('hidden-fields') ?? []);
         $fields = \array_filter(
             $this->entity['list']['fields'],
             function ($name) use ($hiddenFields) {


### PR DESCRIPTION
Hello,
this is a slightly small deprecation fix. A version of symfony/http-foundation since 5.1 will raise a deprecation if you pass a non-string value as second argument for InputBag::get(). 

This fix shouldn't interfere versions below. 

Original deprecation message: 

> Since symfony/http-foundation 5.1: Passing a non-string value as 2nd argument to "Symfony\Component\HttpFoundation\InputBag::get()" is deprecated, pass a string or null instead.