### PR TITLE
Fixes bug with delete from an embedded list

### DIFF
--- a/src/Controller/AdminExtensionControllerTrait.php
+++ b/src/Controller/AdminExtensionControllerTrait.php
@@ -37,7 +37,7 @@ trait AdminExtensionControllerTrait
         $masterRequestUri = \sprintf('%s?%s', \strtok($baseMasterRequestUri, '?'), \http_build_query($queryParameters));
 
         $requestParameters = $this->request->query->all();
-        $requestParameters['referer'] = $masterRequestUri;
+        $requestParameters['referer'] = urlencode($masterRequestUri);
 
         $viewVars = [
             'paginator' => $paginator,


### PR DESCRIPTION
Hi !

When using the open new tab from an embedded list a referer parameter is added to the URL.
This parameter ends up in the referrer URL used for redirection after a delete.
At this moment we have an URL with two `entity` parameters, the one we expected and the one in the referer parameter from the start. The second one, being the last one, overrides the good one.
This causes a display of the wrong list and exception if the URL contains parameters about filters or sort not applicable to the second, wrong, entity.

I'm really not sure about what are the behaviors expected by other users of the lib.
This is not a really nice solution but I didn't manage to find a way for the delete action to either remove the `referer` parameter or use it for redirection. Probably something that would imply modifying the original easy admin bundle, as well.

You probably want to try this out to see if it fits the expected behaviors.