### PR TITLE
Add array typehint on Twig Extensions

### DIFF
--- a/src/Twig/AdminAuthorizationExtension.php
+++ b/src/Twig/AdminAuthorizationExtension.php
@@ -18,14 +18,14 @@ class AdminAuthorizationExtension extends AbstractExtension
         $this->adminAuthorizationChecker = $adminAuthorizationChecker;
     }
 
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('prune_item_actions', [$this, 'pruneItemsActions']),
         ];
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('is_easyadmin_granted', [$this, 'isEasyAdminGranted']),

--- a/src/Twig/CheckboxTreeExtension.php
+++ b/src/Twig/CheckboxTreeExtension.php
@@ -9,7 +9,7 @@ use Twig\TwigFunction;
 
 class CheckboxTreeExtension extends AbstractExtension
 {
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction(

--- a/src/Twig/EmbeddedListExtension.php
+++ b/src/Twig/EmbeddedListExtension.php
@@ -23,14 +23,14 @@ class EmbeddedListExtension extends AbstractExtension
         $this->embeddedListHelper = $embeddedListHelper;
     }
 
-    public function getFilters()
+    public function getFilters(): array
     {
         return [
             new TwigFilter('embedded_list_identifier', [$this, 'getEmbeddedListIdentifier']),
         ];
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('guess_default_filters', [$this, 'guessDefaultFilters']),

--- a/src/Twig/ListFormFiltersExtension.php
+++ b/src/Twig/ListFormFiltersExtension.php
@@ -22,7 +22,7 @@ class ListFormFiltersExtension extends AbstractExtension
         $this->listFormFiltersHelper = $listFormFiltersHelper;
     }
 
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('list_form_filters', [$this, 'getListFormFilters']),


### PR DESCRIPTION
This PR attempt to fix the following deprecation warning:

> 1x: Method "Twig\Extension\ExtensionInterface::getFilters()" might add "array" as a native return type declaration in the future. Do the same in implementation "AlterPHP\EasyAdminExtensionBundle\Twig\EmbeddedListExtension" now to avoid errors or add an explicit @return annotation to suppress this message.

Thanks!